### PR TITLE
GOPATHとGOBINの設定を追加

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -31,6 +31,11 @@ end
 # Rust
 set -gx PATH $HOME/.cargo/bin $PATH
 
+# Go
+set -gx GOPATH $HOME/go
+set -gx GOBIN $GOPATH/bin
+set -gx PATH $GOBIN $PATH
+
 # キーバインド
 function fish_user_key_bindings
   bind \cr peco_select_history


### PR DESCRIPTION
`go install ...` したCLIツールなどを使えるように。